### PR TITLE
Fix bug: if condition for rt value is float or not is incorrect

### DIFF
--- a/code/ms2lda_feature_extraction.py
+++ b/code/ms2lda_feature_extraction.py
@@ -783,7 +783,10 @@ class LoadMSP(Loader):
                                 parentmass = float(val)
                             elif key == 'retentiontime':
                                 ## rt must in float format
-                                val = float(val) if isinstance(val, float) else None
+                                try:
+                                    val = float(val)
+                                except:
+                                    val = None
                                 temp_metadata['parentrt'] = val
                                 parentrt = val
                             else:


### PR DESCRIPTION
Using isinstance function is incorrect here, it will make all val to be None.